### PR TITLE
img-responsive → img-fluid, drop table-hover as default, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,57 +1,58 @@
-bootstrapify
-===================================
+# bootstrapify
 
 This [pelican](https://github.com/getpelican/pelican) plugin modifies article and page html to use bootstrap's default classes. This is especially handy if you want to write tables in markdown, since the `attr_list` extension does not play nice with `tables`.
 
-#Requirements
-*   Beautifulsoup4 - install via `pip install beautifulsoup4`
+## Requirements
 
-#Features
-*   Adds `table table-striped table-hover` to all `<table>` elements.
-*   Adds `img-responsive` to all `<img>` elements.
-*   Use `BOOTSTRAPIFY` in your Pelican configuration file to pass a `{'css-selector': ['list-of-classes']}` dictionary to the plugin. Bootstrapify will append `list-of-classes` to all tags that match `css-selector`. The selector can be as simple as a tag name (`table` or `p`) or as complicated as `a.menu:nth-of-type(3)` (see the [Beautifulsoup4 documentation](http://www.crummy.com/software/BeautifulSoup/bs4/doc/#css-selectors)).
+* Beautifulsoup4 - install via `pip install beautifulsoup4`
 
-#Example for md tables
+## Features
+
+* Adds `table table-striped table-hover` to all `<table>` elements.
+* Adds `img-responsive` to all `<img>` elements.
+* Use `BOOTSTRAPIFY` in your Pelican configuration file to pass a `{'css-selector': ['list-of-classes']}` dictionary to the plugin. Bootstrapify will append `list-of-classes` to all tags that match `css-selector`. The selector can be as simple as a tag name (`table` or `p`) or as complicated as `a.menu:nth-of-type(3)` (see the [Beautifulsoup4 documentation](http://www.crummy.com/software/BeautifulSoup/bs4/doc/#css-selectors)).
+
+## Example for md tables
+
 1. Write your table in markdown
 
-    ```
-    | Protocol       | Contact Information
-    |:-------------- |:-----------------------------------------------------|
-    | jabber/xmpp    | [winlu@jabber.at](winlu@jabber.at)                   |
-    | email          | [derwinlu@gmail.com](mailto:derwinlu@gmail.com)      |
-    | IRC - freenode | winlu                                                |
-    ```
-
+```markdown
+| Protocol       | Contact Information
+|:-------------- |:-----------------------------------------------------|
+| jabber/xmpp    | [winlu@jabber.at](winlu@jabber.at)                   |
+| email          | [derwinlu@gmail.com](mailto:derwinlu@gmail.com)      |
+| IRC - freenode | winlu                                                |
+```
 
 2. there is no step 2, the plugin adds the needed classes to the `<table>` node, resulting in the following output:
 
 
-    ```
-    <table class="table table-striped table-hover">
-    <thead>
+```html
+<table class="table table-striped table-hover">
+  <thead>
     <tr>
-    <th align="left">Protocol</th>
-    <th align="left">Contact Information</th>
+      <th align="left">Protocol</th>
+      <th align="left">Contact Information</th>
     </tr>
-    </thead>
-    <tbody>
+  </thead>
+  <tbody>
     <tr>
-    <td align="left">jabber/xmpp</td>
-    <td align="left"><a href="winlu@jabber.at">winlu@jabber.at</a></td>
-    </tr>
-    <tr>
-    <td align="left">email</td>
-    <td align="left"><a href="mailto:derwinlu@gmail.com">derwinlu@gmail.com</a></td>
+      <td align="left">jabber/xmpp</td>
+      <td align="left"><a href="winlu@jabber.at">winlu@jabber.at</a></td>
     </tr>
     <tr>
-    <td align="left"><span class="caps">IRC</span> - freenode</td>
-    <td align="left">winlu</td>
+      <td align="left">email</td>
+      <td align="left"><a href="mailto:derwinlu@gmail.com">derwinlu@gmail.com</a></td>
     </tr>
-    </tbody>
-    </table>
-    ```
+    <tr>
+      <td align="left"><span class="caps">IRC</span> - freenode</td>
+      <td align="left">winlu</td>
+    </tr>
+  </tbody>
+</table>
+```
 
+## Known Issues
 
-#Known Issues
-*   plugin seems not to fire for drafts
-*   not enough customization possible, maybe read article,page metadata for more options
+* plugin seems not to fire for drafts
+* not enough customization possible, maybe read article,page metadata for more options

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This [pelican](https://github.com/getpelican/pelican) plugin modifies article an
 ## Features
 
 * Adds `table table-striped table-hover` to all `<table>` elements.
-* Adds `img-responsive` to all `<img>` elements.
+* Adds `img-fluid` to all `<img>` elements.
 * Use `BOOTSTRAPIFY` in your Pelican configuration file to pass a `{'css-selector': ['list-of-classes']}` dictionary to the plugin. Bootstrapify will append `list-of-classes` to all tags that match `css-selector`. The selector can be as simple as a tag name (`table` or `p`) or as complicated as `a.menu:nth-of-type(3)` (see the [Beautifulsoup4 documentation](http://www.crummy.com/software/BeautifulSoup/bs4/doc/#css-selectors)).
 
 ## Example for md tables

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This [pelican](https://github.com/getpelican/pelican) plugin modifies article an
 
 ## Features
 
-* Adds `table table-striped table-hover` to all `<table>` elements.
+* Adds `table table-striped` to all `<table>` elements.
 * Adds `img-fluid` to all `<img>` elements.
 * Use `BOOTSTRAPIFY` in your Pelican configuration file to pass a `{'css-selector': ['list-of-classes']}` dictionary to the plugin. Bootstrapify will append `list-of-classes` to all tags that match `css-selector`. The selector can be as simple as a tag name (`table` or `p`) or as complicated as `a.menu:nth-of-type(3)` (see the [Beautifulsoup4 documentation](http://www.crummy.com/software/BeautifulSoup/bs4/doc/#css-selectors)).
 

--- a/bootstrapify.py
+++ b/bootstrapify.py
@@ -12,7 +12,7 @@ from pelican import signals, contents
 
 BOOTSTRAPIFY_DEFAULT = {
     'table': ['table', 'table-striped', 'table-hover'],
-    'img': ['img-responsive']
+    'img': ['img-fluid']
 }
 BOOTSTRAPIFY_KEY = 'BOOTSTRAPIFY'
 

--- a/bootstrapify.py
+++ b/bootstrapify.py
@@ -11,7 +11,7 @@ from bs4 import BeautifulSoup
 from pelican import signals, contents
 
 BOOTSTRAPIFY_DEFAULT = {
-    'table': ['table', 'table-striped', 'table-hover'],
+    'table': ['table', 'table-striped'],
     'img': ['img-fluid']
 }
 BOOTSTRAPIFY_KEY = 'BOOTSTRAPIFY'


### PR DESCRIPTION
Hi, starting using this plugin and encountered some things I would change:

- Responsive image class has been renamed to `img-fluid` in bootstrap 4: https://getbootstrap.com/docs/4.0/migration/#images
- Drop `table-hover` as default: feels quite opinionated as a default style choice, users can still set this via `BOOTSTRAPIFY` if needed
- Clean up README: Markdown corrections, syntax highlighting, indented HTML